### PR TITLE
Implement a Method to Apply Gateway Standards to APIs

### DIFF
--- a/apim-gw-aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayDeployer.java
+++ b/apim-gw-aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayDeployer.java
@@ -11,6 +11,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.ConfigurationDto;
 import org.wso2.carbon.apimgt.api.model.Environment;
+import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.deployer.ExternalGatewayDeployer;
 import org.wso2.carbon.apimgt.impl.deployer.exceptions.DeployerException;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
@@ -143,5 +144,15 @@ public class AWSGatewayDeployer implements ExternalGatewayDeployer {
             throw new DeployerException("Error while getting resolved API invocation URL", e);
         }
         return resolvedUrl.toString() + "/" + environment.getAdditionalProperties().get("stage");
+    }
+
+    @Override
+    public void applyGatewayStandards(API api) throws DeployerException {
+        // change all /* resources to / in the resources list
+        for(URITemplate resource: api.getUriTemplates()) {
+            if (resource.getUriTemplate().endsWith("/*")) {
+                resource.setUriTemplate(resource.getUriTemplate().replace("/*", "/"));
+            }
+        }
     }
 }


### PR DESCRIPTION
### Description
- [x] Apply AWS related standards to APIs 

### Remarks
"/*" resources are not supported in AWS API Gateway. Hence resources having "/*" are converted into "/" format for AWS gateway deployed APIs